### PR TITLE
Fix SyntaxError: Identifier 'w' has already been declared

### DIFF
--- a/packages/nuxt-delay-hydration/src/runtime/nitro-plugin.ts
+++ b/packages/nuxt-delay-hydration/src/runtime/nitro-plugin.ts
@@ -93,7 +93,7 @@ export default <NitroAppPlugin> function (nitro) {
 
     // insert the hydration API, maybe insert delay script
     htmlContext.bodyAppend.push(`<script>
-const w = window
+if (typeof w === 'undefined') { const w = window };
 w._$delayHydration = (() => {
   ${script}}
 )();


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix for  Uncaught SyntaxError: Identifier 'w' has already been declared

### Linked Issues
https://github.com/harlan-zw/nuxt-delay-hydration/issues/20


### Additional context
Replace  `const w = window`  with :  `if (typeof w === 'undefined') { const w = window };`

Always check if **w** is already assigned because w may be defined by other plugins (example: @nuxtjs/color-mode)
