### PR TITLE
fix: replace vulnerable lodash.template module with lodash-es

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^3.5.1",
-    "@types/lodash.template": "^4.5.1",
-    "lodash.template": "^4.5.0",
+    "lodash-es": "^4.17.21",
     "packrup": "^0.1.0",
     "radix3": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@nuxt/test-utils": "^3.5.1",
     "@nuxt/types": "^2.16.3",
     "@types/fs-extra": "^11.0.1",
+    "@types/lodash-es": "^4.17.7",
     "@types/node": "^20.2.3",
     "@vitest/ui": "^0.31.1",
     "bumpp": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@types/fs-extra':
         specifier: ^11.0.1
         version: 11.0.1
+      '@types/lodash-es':
+        specifier: ^4.17.7
+        version: 4.17.7
       '@types/node':
         specifier: ^20.2.3
         version: 20.2.3
@@ -1313,6 +1316,12 @@ packages:
     resolution: {integrity: sha512-1YXyYH83h6We1djyoUEqTlVyQtCfJAFXELSKW2ZRtjHD4hQ82CC4lvrv5D0l0FLcKBaiPbXyi3MpMsI9ZRgKsw==}
     dev: true
 
+  /@types/lodash-es@4.17.7:
+    resolution: {integrity: sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==}
+    dependencies:
+      '@types/lodash': 4.14.191
+    dev: true
+
   /@types/lodash.template@4.5.1:
     resolution: {integrity: sha512-0y71S2dGgmwdkSsyW95JBp8HSZchgKCsjr6F0lsT3eSMtaT3Nn9rcMHU1U4UKu6XjQT3YC6/PNwgFI7k9f+ltw==}
     dependencies:
@@ -1321,7 +1330,6 @@ packages:
 
   /@types/lodash@4.14.191:
     resolution: {integrity: sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==}
-    dev: false
 
   /@types/mdast@3.0.11:
     resolution: {integrity: sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -7,12 +11,9 @@ importers:
       '@nuxt/kit':
         specifier: ^3.5.1
         version: 3.5.1(rollup@3.23.0)
-      '@types/lodash.template':
-        specifier: ^4.5.1
-        version: 4.5.1
-      lodash.template:
-        specifier: ^4.5.0
-        version: 4.5.0
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       packrup:
         specifier: ^0.1.0
         version: 0.1.0
@@ -4434,6 +4435,10 @@ packages:
     dependencies:
       p-locate: 5.0.0
     dev: true
+
+  /lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
 
   /lodash._reinterpolate@3.0.0:
     resolution: {integrity: sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==}

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,6 @@
 import { promises as fsp } from 'node:fs'
 import { addComponentsDir, addPlugin, addTemplate, createResolver, defineNuxtModule } from '@nuxt/kit'
-import template from 'lodash.template'
+import { template } from 'lodash-es'
 
 export type Mode = 'init' | 'mount' | 'manual' | false
 export type EventTypes = 'mousemove' | 'scroll' | 'wheel' | 'keydown' | 'click' | 'touchstart' | string


### PR DESCRIPTION
### Description
This merge request proposes the replacement of the lodash.template module with the lodash-es module and the utilization of its internal template method. The reason for this change is due to the known vulnerability of command injection associated with the lodash.template module, as reported by Snyk.

https://security.snyk.io/package/npm/lodash.template
