### PR TITLE
fix: remove links preload script at init mode when using Nuxt SSG

### DIFF
--- a/src/runtime/nitro-plugin.ts
+++ b/src/runtime/nitro-plugin.ts
@@ -58,6 +58,9 @@ export default <NitroAppPlugin>function(nitro) {
       const $config = useRuntimeConfig()
       const ASSET_RE = new RegExp(`<script[^>]*src="${$config.app.buildAssetsDir}[^>]+><\\/script>`)
 
+      const LINK_ASSET_RE = new RegExp(`<link rel="modulepreload" as="script" [^>]*href="${$config.app.buildAssetsDir}[^>]+>`, "g");
+      htmlContext.head = htmlContext.head.map((head: string) => head.replaceAll(LINK_ASSET_RE, ""))
+
       const toLoad: Record<string, any>[] = []
       const ssrContext = htmlContext.bodyAppend.find(b => b.includes('window.__NUXT__'))
       const NUXT_DATA_RE = /<script type="application\/json" id="__NUXT_DATA__"[^>]*>(.*?)<\/script[^>]*>/g


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I am using this awesome library with Nuxt in SSG mode. It works very well when using the 'mount' mode, but I noticed that it doesn't delay all scripts from loading when using the 'init' mode. When I dug deeper into the source code, I discovered that in 'init' mode, the library removes script tags from the body. However, when I use Nuxt in SSG mode, those js script are placed inside the head tag using a link tag like this:
```
<link rel="modulepreload" as="script" crossorigin href="/_nuxt/entry.81e73eaf.js">
```
Therefore, I created this PR to remove those link tags containing JS scripts as mentioned above, to ensure that the 'init' mode functions correctly in Nuxt SSG mode.
I have limited experience contributing to open-source projects and I hope to receive feedback and suggestions from everyone. I also hope that my PR will be merged to help others.
### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
