### PR TITLE
fix: ReferenceError for undefined TouchEvent in Firefox (#37, #26)

### DIFF
--- a/src/template/replay.ts
+++ b/src/template/replay.ts
@@ -1,6 +1,6 @@
 (() => {
   w._$delayHydration.then((e: Event) => {
-    if (!(e instanceof PointerEvent) && !(e instanceof MouseEvent) && !(e instanceof TouchEvent))
+    if (!(e instanceof PointerEvent) && !(e instanceof MouseEvent) && !(window.TouchEvent && e instanceof TouchEvent))
       return
 
     if (e instanceof MouseEvent && e.type !== 'click')


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix "ReferenceError: TouchEvent is not defined" on Firefox when hydration is triggered by timeout.

### Linked Issues

- Fixes #37
- Fixes #26

