### PR TITLE
doc: better v0 readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Keep in mind, **this is a hacky solution**. Until Google can recognise which scr
 
 ```bash
 yarn add nuxt-delay-hydration
-# npm i nuxt-delay-hydration
+# npm i nuxt-delay-hydration@0.4.7
 ```
 
 _Requirement: SSR, full-static (SSG) is highly recommended._


### PR DESCRIPTION
Added the highest version the user should install if they are using Nuxt2. If the user enters ```npm i nuxt-delay-hydration```, they'll get version 1.33 and it won't work on Nuxt2.

<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
