### PR TITLE
fix: `replayClick` always being applied

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -123,8 +123,10 @@ export default defineNuxtModule<ModuleOptions>({
       scripts[s] = template(scriptT)({ options })
     }
 
+  const replayClickScript =  options.replayClick ? scripts.replay : false
+
     const exports = `export const script = ${JSON.stringify(scripts.global, null, 2)}
-export const replayScript = ${JSON.stringify(scripts.replay, null, 2)}
+export const replayScript = ${JSON.stringify(replayClickScript, null, 2)}
 export const mode = ${JSON.stringify(options.mode)}
 export const include = ${JSON.stringify(options.include)}
 export const exclude = ${JSON.stringify(options.exclude)}


### PR DESCRIPTION
### Description

This PR fixes the `replayClick` option. Until now, the replay script was always added to the HTML source regardless the option was set to false or not used. Hence, all click or touch events before hydration is replayed.

This solves a couple of things:
1. `replayClick` option will work as intended (false) as default
2. Fixes the link trigger issues on mobile devices on touch since the touch events are being replayed if the hydration event is not completed.

### Linked Issues

1.  https://github.com/harlan-zw/nuxt-delay-hydration/issues/54
2.  https://github.com/harlan-zw/nuxt-delay-hydration/issues/53
3.  https://github.com/harlan-zw/nuxt-delay-hydration/issues/47

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
