### PR TITLE
fix: replayClick script

### DIFF
--- a/src/runtime/template/replay.mjs
+++ b/src/runtime/template/replay.mjs
@@ -1,1 +1,1 @@
-(()=>{w._$delayHydration.then(e=>{if(e instanceof PointerEvent||e instanceof MouseEvent&&e.type!=="click"||window.TouchEvent&&e instanceof TouchEvent){setTimeout(()=>w.requestIdleCallback(()=>setTimeout(()=>e.target&&e.target.click(),500)),50)}})})();
+(()=>{w._$delayHydration.then(e=>{if(e instanceof PointerEvent||e instanceof MouseEvent&&e.type==="click"||window.TouchEvent&&e instanceof TouchEvent){setTimeout(()=>w.requestIdleCallback(()=>setTimeout(()=>e.target&&e.target.click(),500)),50)}})})();

--- a/src/template/replay.mjs
+++ b/src/template/replay.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable */
 (() => {
   w._$delayHydration.then((e) => {
-    if (e instanceof PointerEvent || (e instanceof MouseEvent && e.type !== 'click') || (window.TouchEvent && e instanceof TouchEvent)) {
+    if (e instanceof PointerEvent || (e instanceof MouseEvent && e.type === 'click') || (window.TouchEvent && e instanceof TouchEvent)) {
       setTimeout(() => {
         return w.requestIdleCallback(() => setTimeout(() => e.target && e.target.click(), 500));
       }, 50);


### PR DESCRIPTION
### Description

In the `replayClick` script there is a simple logic mistake were click being triggered on non `Click` events, rather than the `Click` events. 
ReplayClick should trigger on click events and not the other events like scroll, mousemove etc 

### Linked Issues

I haven't raised an issue since it's a simple fix, but below is a replication of how this can be an issue. 
If a page has a huge element with a href or click action, just hovering or moving mouse over this element before hydration event can cause the click to trigger.
I think the logic got messed up in the below commit where before if the click event type was of `click`, function was returned. 

https://github.com/harlan-zw/nuxt-delay-hydration/commit/24f05c75329922f19bc0ac178953017eaadaf165

Issue replicated: https://stackblitz.com/edit/nuxt-starter-n7nihz?file=app.vue


### Additional context

Thanks for this amazing package. I hope to contribute more :)
